### PR TITLE
サイドパネル・ページへの導線改善

### DIFF
--- a/frontend/manifest.json
+++ b/frontend/manifest.json
@@ -21,11 +21,10 @@
   },
   "host_permissions": ["<all_urls>"],
   "action": {
-    "default_popup": "./dist/popup/popup.html",
     "default_icon": "kateikyoushi_woman_boy.png"
   },
   "side_panel": {
-   "default_path": "./dist/sidepanel/sidepanel.html"
+    "default_path": "./dist/sidepanel/sidepanel.html"
   },
   "icons": {
     "128": "kateikyoushi_woman_boy.png"

--- a/frontend/src/background/index.ts
+++ b/frontend/src/background/index.ts
@@ -2,25 +2,32 @@
 chrome.runtime.onInstalled.addListener(() => {
   console.log("AI家庭教師くんがインストールされました！");
   chrome.contextMenus.create({
-    id: "sampleMenu",
-    title: "メニューをクリック",
+    id: "pageMenu",
+    title: "AI家庭教師くんを開く",
     contexts: ["all"], // メニューを表示するコンテキスト（例: ページ, リンクなど）
   });
 });
 
 // メニュークリック時のイベントリスナーを追加
 chrome.contextMenus.onClicked.addListener((info, tab) => {
-  if (info.menuItemId === "sampleMenu") {
-    console.log("アイコンがクリックされました！");
-  }
-  const url = ((selectionText: string | undefined) => {
-    if (selectionText == null || selectionText === "") {
-      return `dist/page/index.html`;
-    }
-    return `dist/page/index.html?selected_text=${selectionText}`;
-  })(info.selectionText);
-  if (info.selectionText)
-    chrome.tabs.create({ url }).catch((err) => console.log(err));
+  chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+    const tab = tabs[0];
+    chrome.sidePanel.open({
+      windowId: tab.windowId,
+      tabId: tab.id,
+    });
+  });
+});
+
+// アクションボタンをクリックしたときのイベントリスナーを追加
+chrome.action.onClicked.addListener(() => {
+  chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+    const tab = tabs[0];
+    chrome.sidePanel.open({
+      windowId: tab.windowId,
+      tabId: tab.id,
+    });
+  });
 });
 
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {

--- a/frontend/src/sidepanel/SidePanel.tsx
+++ b/frontend/src/sidepanel/SidePanel.tsx
@@ -31,11 +31,25 @@ export const SidePanel: React.FC = () => {
     setCards(cards.map((card) => ({ ...card, pageInfo })));
   }, [pageInfo]);
 
+  const handleOpenAnalysis = () => {
+    const url = "dist/page/index.html";
+    // chrome.tabs.create は Chrome Extension 環境向け
+    if (chrome && chrome.tabs && chrome.tabs.create) {
+      chrome.tabs
+        .create({ url })
+        .catch((err) => console.log("タブ作成エラー:", err));
+    } else {
+      // 拡張機能でない場合は window.open にフォールバック
+      window.open(url, "_blank");
+    }
+  };
+
   return (
     <>
       <SidePanelHeader />
       <div>
         <button onClick={resetStates}>リセット</button>
+        <button onClick={handleOpenAnalysis}>分析結果を開く</button>
       </div>
       <div style={{ margin: "30px auto" }}>
         <SortableList


### PR DESCRIPTION
- chrome上部のアイコンクリック時に、サイドパネルを開く
- 画面上で右クリックして表示されるメニュークリック時に、サイドパネルを開く
- サイドパネルから、ページへ移動できるようにする

- popupは廃止

![スクリーンショット 2025-02-09 10 56 33](https://github.com/user-attachments/assets/f3f206ca-d918-4fd3-86ff-374d1a9acfcb)
![スクリーンショット 2025-02-09 11 03 38](https://github.com/user-attachments/assets/212909b0-9f3c-4c1b-ad54-5700f1813603)
![スクリーンショット 2025-02-09 11 07 12](https://github.com/user-attachments/assets/c4e37787-1d7e-4b35-8bd7-fe17ed9353bf)
