### PR TITLE
backendのデプロイを自動化

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,14 +33,10 @@ jobs:
         working-directory: ./backend
         run: |
           docker build -t us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/cloud-run-source-deploy/fastapi-app:latest .
-        # <IMAGE_URI> を以下の形式で置き換えてください:
-        # <ARTIFACT_REGISTRY_HOST>/<GCP_PROJECT_ID>/<REPOSITORY>/<IMAGE_NAME>:<TAG>
-        # <DOCKERFILEのあるパス> を Dockerfile の場所に置き換えてください。通常は "."
 
       - name: Docker イメージを Artifact Registry にプッシュ
         run: |
           docker push us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/cloud-run-source-deploy/fastapi-app:latest
-        # <IMAGE_URI> はビルド時と同じものを指定します
 
       - name: Cloud Run にデプロイ
         run: |
@@ -49,5 +45,3 @@ jobs:
             --region us-central1 \
             --platform managed \
             --allow-unauthenticated
-        # <CLOUD_RUN_SERVICE_NAME> を Cloud Run のサービス名に置き換えてください
-        # <CLOUD_RUN_REGION> をデプロイ先のリージョンに置き換えてください

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,13 +1,9 @@
 name: Deploy to Cloud Run
 
-# on:
-#   push:
-#     branches:
-#       - main # トリガーとなるブランチ名
 on:
   push:
     branches:
-      - feature/auto-deploy
+      - main # トリガーとなるブランチ名
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,57 @@
+name: Deploy to Cloud Run
+
+# on:
+#   push:
+#     branches:
+#       - main # トリガーとなるブランチ名
+on:
+  push:
+    branches:
+      - feature/auto-deploy
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    name: Build and Deploy to Cloud Run
+
+    steps:
+      - name: コードをチェックアウト
+        uses: actions/checkout@v3
+
+      - name: Google Cloud に認証
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: "${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}"
+
+      - name: Cloud SDK をセットアップ
+        uses: google-github-actions/setup-gcloud@v1
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          export_default_credentials: true # 認証情報を環境変数に設定
+
+      - name: Docker を Artifact Registry 用に設定
+        run: |
+          gcloud auth configure-docker us-central1-docker.pkg.dev
+
+      - name: Docker イメージをビルド
+        working-directory: ./backend
+        run: |
+          docker build -t us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/cloud-run-source-deploy/fastapi-app:latest .
+        # <IMAGE_URI> を以下の形式で置き換えてください:
+        # <ARTIFACT_REGISTRY_HOST>/<GCP_PROJECT_ID>/<REPOSITORY>/<IMAGE_NAME>:<TAG>
+        # <DOCKERFILEのあるパス> を Dockerfile の場所に置き換えてください。通常は "."
+
+      - name: Docker イメージを Artifact Registry にプッシュ
+        run: |
+          docker push us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/cloud-run-source-deploy/fastapi-app:latest
+        # <IMAGE_URI> はビルド時と同じものを指定します
+
+      - name: Cloud Run にデプロイ
+        run: |
+          gcloud run deploy fastapi-app \
+            --image us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/cloud-run-source-deploy/fastapi-app:latest \
+            --region us-central1 \
+            --platform managed \
+            --allow-unauthenticated
+        # <CLOUD_RUN_SERVICE_NAME> を Cloud Run のサービス名に置き換えてください
+        # <CLOUD_RUN_REGION> をデプロイ先のリージョンに置き換えてください


### PR DESCRIPTION
mainにpushした時に自動で
- コンテナビルド
- イメージをArtifact Registryにプッシュ
- Cloud Runの更新
を行う

debug用にfeature/auto-deployでテストしました
https://github.com/motsupot/katekyoshi-kun/actions/runs/13225262066/job/36915402499

### Artifact Regisrty へのpushを確認（latestタグ）
![image](https://github.com/user-attachments/assets/defde9cf-8a71-4cbe-a87e-a205192bf68a)

### Cloud Run（latestタグを参照している）
![image](https://github.com/user-attachments/assets/15b310b7-e2e0-4bff-be1a-216685dddb4b)

